### PR TITLE
test: add unit test for app and header component

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
-// import { render, screen } from '@testing-library/react';
-// import App from './App';
+import { render } from '@testing-library/react'
+import App from './App'
 
-// test('renders learn react link', () => {
-//   render(<App />);
-//   const linkElement = screen.getByText(/learn react/i);
-//   expect(linkElement).toBeInTheDocument();
-// });
+describe('App', () => {
+ test('Renders without crashing', () => {
+  render(<App />)
+ })
+})

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import Header from './Header'
+
+describe('Header', () => {
+ test('Renders Header component links correctly with imported data', () => {
+  const data = [
+   {
+    title: 'GITHUB',
+    url: 'https://github.com/kimbcheh',
+   },
+  ]
+  render(<Header linkData={data} />)
+  expect(screen.getByText('GITHUB')).toBeInTheDocument()
+  expect(screen.getByRole('link')).toHaveAttribute(
+   'href',
+   'https://github.com/kimbcheh'
+  )
+ })
+})


### PR DESCRIPTION
**Description**
 :bulb: Add unit test to ensure `Header` component renders data correctly and `App` component renders without crashing.

**Changes**
- Add unit test for `Header` and `App` component
- Remove create-react-app's default `App` test