### PR TITLE
fix: move list tag in about component

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -18,16 +18,14 @@ function About() {
     <p>
      On a more personal note, I'm a huge fan of good design and coffee! &#9749;
     </p>
-    <p>
-     Some technology I've worked with...
-     <ul>
-      <li>— LANGUAGES: HTML5, CSS3 AND JAVASCRIPT ES6</li>
-      <li>— FRAMEWORKS: REACT</li>
-      <li>
-       — OTHER: VERSION CONTROL, RESTFUL API, CSS FRAMEWORKS, SASS AND FIGMA
-      </li>
-     </ul>
-    </p>
+    <p>Some technology I've worked with...</p>
+    <ul>
+     <li>— LANGUAGES: HTML5, CSS3 AND JAVASCRIPT ES6</li>
+     <li>— FRAMEWORKS: REACT</li>
+     <li>
+      — OTHER: VERSION CONTROL, RESTFUL API, CSS FRAMEWORKS, SASS AND FIGMA
+     </li>
+    </ul>
    </div>
   </section>
  )


### PR DESCRIPTION
**Description**
Move `<ul>` outside of `<p>` tag in `About` component

Addresses this error in console:
![image](https://user-images.githubusercontent.com/83323970/124604282-2157a580-deae-11eb-9024-618b43508e49.png)
